### PR TITLE
Modified startTag regex to allow for numbers in namespace prefixes.

### DIFF
--- a/src/jsxml.js
+++ b/src/jsxml.js
@@ -18,7 +18,7 @@
    * http://erik.eae.net/simplehtmlparser/simplehtmlparser.js
    */
 	// Regular Expressions for parsing tags and attributes
-	var startTag = /^<([a-zA-Z\$_]+:{0,1}[a-zA-Z0-9\$\-_]*)((?:\s+[a-zA-Z\$_]+:{0,1}[a-zA-Z0-9\$\-_]*(?:\s*=\s*(?:(?:"[^"]*")|(?:'[^']*')|[^>\s]+))?)*)\s*(\/?)>/,
+	var startTag = /^<([0-9a-zA-Z\$_]+:{0,1}[a-zA-Z0-9\$\-_]*)((?:\s+[a-zA-Z\$_]+:{0,1}[a-zA-Z0-9\$\-_]*(?:\s*=\s*(?:(?:"[^"]*")|(?:'[^']*')|[^>\s]+))?)*)\s*(\/?)>/,
 	  endTag = /^<\/([a-zA-Z0-9\$\-_:]+)[^>]*>/,
     attr = /([a-zA-Z\$_]+:{0,1}[a-zA-Z0-9\$\-_]*)(?:\s*=\s*(?:(?:"((?:\\.|[^"])*)")|(?:'((?:\\.|[^'])*)')|([^>\s]+)))?/g,
 		_parseXML,


### PR DESCRIPTION
According to the XML W3C spec recommendation (http://www.w3.org/TR/xml-names11/#NT-Prefix) a namespace prefix can contain digits, but the `startTag` regex doesn't currently allow for this. Without this change, jsxml throws `[XML Parse Error] the start tag is invalid ...` for an XML tag such as `<ns3:someTagName> ...`
